### PR TITLE
Correcltly reading the number of electrons

### DIFF
--- a/src/libxtp/qmpackages/nwchem.cc
+++ b/src/libxtp/qmpackages/nwchem.cc
@@ -535,7 +535,7 @@ namespace votca {
             for (i = 1; i <= _n_lines; i++) {
                 for (int j = 0; j < 3; j++) {
                     _input_file >> _occ[ _imo ];
-                    if (_occ[ _imo ] == 2.0) {
+                    if (_occ[ _imo ] != 0.0) {
                         _number_of_electrons++;
                     }
                     _imo++;


### PR DESCRIPTION
I'm not sure if this change is correct. Because I don't know why he should add an electron only for an occupation of 2.
I generated some calculations where the movec file was constituted of 1 instead of 2.

Checking with the main log file from nwchem, it makes sense to add electron for numbers which are different than 2.
See issue https://github.com/votca/xtp/issues/143 for more details.

Furthermore, this routine should count only alpha electrons?